### PR TITLE
Create crossdomain.xml

### DIFF
--- a/crossdomain.xml
+++ b/crossdomain.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!DOCTYPE cross-domain-policy SYSTEM "http://www.macromedia.com/xml/dtds/cross-domain-policy.dtd">
+<cross-domain-policy>
+   <site-control permitted-cross-domain-policies="master-only"/>
+   <allow-access-from domain="*.pythonanywhere.com"/>
+   <allow-access-from domain="www.pythonanywhere.com"/>
+   <allow-http-request-headers-from domain="*.pythonanywhere.com" headers="SOAPAction,Content-Type"/>
+</cross-domain-policy>


### PR DESCRIPTION
A crossdomain.xml with wildcard * (or if it's not present itself) can result in SOP bypass and extracting Anti CSRF.